### PR TITLE
Add tensorflow-metal to Mac setup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,8 @@ pc =
     albumentations
 
 macos =
-    tensorflow-macos==2.9
+    tensorflow-macos==2.9.2
+    tensorflow-metal=0.5.1
     matplotlib
     kivy==2.1
     pandas


### PR DESCRIPTION
Tensorflow-metal will accelerate tensorflow by leveraging the GPUs in both Intel and ARM (M1 M2 M3) based Macs.